### PR TITLE
chore: update @npmcli/arborist to 0.0.0-pre.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,9 +133,9 @@
       }
     },
     "@npmcli/arborist": {
-      "version": "0.0.0-pre.20",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.0-pre.20.tgz",
-      "integrity": "sha512-ILYXVLsWmqdC9UJY238NOXkNnfM9/3dhQKwAApPRDIgmciC/rUb7KIg5R3sbDA/LmurXGZ3wgtzgn6VokJfqZQ==",
+      "version": "0.0.0-pre.21",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.0-pre.21.tgz",
+      "integrity": "sha512-WQ/t8dmeo5ea8+8WRTojLetS6rBbyC5i+GAFyH91YGe+T2X3OLhHV0xkif9TEjoGE0Nb2HGYXXk8NBq6hcwmKA==",
       "requires": {
         "@npmcli/installed-package-contents": "^1.0.5",
         "@npmcli/map-workspaces": "0.0.0-pre.1",
@@ -311,17 +311,17 @@
       "dev": true
     },
     "agent-base": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
       "requires": {
         "debug": "4"
       }
     },
     "agentkeepalive": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.2.tgz",
-      "integrity": "sha512-waNHE7tQBBn+2qXucI8HY0o2Y0OBPWldWOWsZwY71JcCm4SvrPnWdceFfB5NIXSqE8Ewq6VR/Qt5b1i69P6KCQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.3.tgz",
+      "integrity": "sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==",
       "requires": {
         "debug": "^4.1.0",
         "depd": "^1.1.2",
@@ -2973,9 +2973,9 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.0.tgz",
-      "integrity": "sha512-RkcugRDye2j6yEiHGMyAdKQoipgp8VToSIjm+TFLhVraXOkC/WU2kjE2URcYBpcJ4hs++VFBKo6+Zg4wmrS+Qw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.1.tgz",
+      "integrity": "sha512-3FCYb/YO6k9vfPMSU6H1CbixQAzoLuBqTTpjcks2PHlN59c0ENTYrDF8lCRvgLm1iAhwhwZg7pRq2VOTw3Yfaw==",
       "requires": {
         "@npmcli/ci-detect": "^1.0.0",
         "lru-cache": "^5.1.1",
@@ -3927,9 +3927,9 @@
       "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
     },
     "socks": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.4.1.tgz",
+      "integrity": "sha512-8mWHeYC1OA0500qzb+sqwm0Hzi8oBpeuI1JugoBVMEJtJvxSgco8xFSK+NRnZcHeeWjTbF82KUDo5sXH22TY5A==",
       "requires": {
         "ip": "1.1.5",
         "smart-buffer": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "tap": "^14.10.7"
   },
   "dependencies": {
-    "@npmcli/arborist": "0.0.0-pre.20"
+    "@npmcli/arborist": "0.0.0-pre.21"
   }
 }


### PR DESCRIPTION
Once we land this, need to do the same in npm/cli, so that `npm audit` will work properly with bundled deps.