### PR TITLE
feat: add support to filtering by workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Options:
 - `countOnly`: Uses the tree-traversal logic from **npm fund** but skips over
 any obj definition and just returns an obj containing `{ length }` - useful for
 things such as printing a `6 packages are looking for funding` msg.
-- `path`: Location to current working directory
+- `workspaces`: `Array<String>` List of workspaces names to filter for,
+the result will only include a subset of the resulting tree that includes
+only the nodes that are children of the listed workspaces names.
+- `path`, `registry` and more [Arborist](https://github.com/npm/arborist/) options.
 
 ##### <a name="fund.readTree"></a> `> fund.readTree(tree, [opts]) -> Promise<Object>`
 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,13 @@ function readTree (tree, opts) {
   const { countOnly } = opts || {}
   const _trailingDependencies = Symbol('trailingDependencies')
 
+  let filterSet
+
+  if (opts && opts.workspaces && opts.workspaces.length) {
+    const arb = new Arborist(opts)
+    filterSet = arb.workspaceDependencySet(tree, opts.workspaces)
+  }
+
   function tracked (name, version) {
     const key = String(name) + String(version)
     if (seen.has(key))
@@ -91,6 +98,9 @@ function readTree (tree, opts) {
 
       const node = edge.to.target || edge.to
       if (!node.package)
+        return empty()
+
+      if (filterSet && filterSet.size > 0 && !filterSet.has(node))
         return empty()
 
       const { name, funding, version } = node.package
@@ -174,8 +184,7 @@ function readTree (tree, opts) {
 
 async function read (opts) {
   const arb = new Arborist(opts)
-  const tree = await arb.loadActual()
-
+  const tree = await arb.loadActual(opts)
   return readTree(tree, opts)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^2.4.4"
+        "@npmcli/arborist": "^2.5.0"
       },
       "devDependencies": {
         "eslint": "^7.26.0",
@@ -540,9 +540,9 @@
       }
     },
     "node_modules/@npmcli/arborist": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.4.4.tgz",
-      "integrity": "sha512-mqZvcPCWT6gSSYxs08aKvXmECXh9fP85q1pUIY/jDkaQ58QTRy6F7XrUQr7F77jXpYfpYKPUi6RhpuSpOXCITA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.5.0.tgz",
+      "integrity": "sha512-YPSkV/8vofpbAJyeu52J12YnC5VTkYIcfcNkRoSW6qjfQG+QybgbJtCbcdx+M0YxfdzDKS6iDTjpNMoETZ8HOA==",
       "dependencies": {
         "@npmcli/installed-package-contents": "^1.0.7",
         "@npmcli/map-workspaces": "^1.0.2",
@@ -7934,9 +7934,9 @@
       "dev": true
     },
     "@npmcli/arborist": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.4.4.tgz",
-      "integrity": "sha512-mqZvcPCWT6gSSYxs08aKvXmECXh9fP85q1pUIY/jDkaQ58QTRy6F7XrUQr7F77jXpYfpYKPUi6RhpuSpOXCITA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.5.0.tgz",
+      "integrity": "sha512-YPSkV/8vofpbAJyeu52J12YnC5VTkYIcfcNkRoSW6qjfQG+QybgbJtCbcdx+M0YxfdzDKS6iDTjpNMoETZ8HOA==",
       "requires": {
         "@npmcli/installed-package-contents": "^1.0.7",
         "@npmcli/map-workspaces": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "tap": "^15.0.9"
   },
   "dependencies": {
-    "@npmcli/arborist": "^2.4.4"
+    "@npmcli/arborist": "^2.5.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1261,3 +1261,98 @@ t.test('invalid funding objects', (t) => {
   )
   t.end()
 })
+
+t.test('workspaces', t => {
+  t.test('filter by workspace', async t => {
+    const path = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+        workspaces: [
+          'packages/*',
+        ],
+        dependencies: {
+          '@npmcli/baz': '^1.0.0',
+        },
+      }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            funding: 'http://example.com/a',
+            dependencies: {
+              '@npmcli/foo': '^1.0.0',
+            },
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: 'b',
+            version: '1.0.0',
+            devDependencies: {
+              '@npmcli/bar': '^1.0.0',
+            },
+          }),
+        },
+      },
+      node_modules: {
+        a: t.fixture('symlink', '../packages/a'),
+        b: t.fixture('symlink', '../packages/b'),
+        '@npmcli': {
+          foo: {
+            'package.json': JSON.stringify({
+              name: '@npmcli/foo',
+              version: '1.0.0',
+              funding: 'http://example.com/foo',
+            }),
+          },
+          bar: {
+            'package.json': JSON.stringify({
+              name: '@npmcli/bar',
+              version: '1.0.0',
+              funding: 'http://example.com/bar',
+            }),
+          },
+          baz: {
+            'package.json': JSON.stringify({
+              name: '@npmcli/baz',
+              version: '1.0.0',
+              funding: 'http://example.com/baz',
+            }),
+          },
+        },
+      },
+    })
+
+    const expected = {
+      dependencies: {
+        a: {
+          funding: {
+            url: 'http://example.com/a',
+          },
+          version: '1.0.0',
+          dependencies: {
+            '@npmcli/foo': {
+              funding: {
+                url: 'http://example.com/foo',
+              },
+              version: '1.0.0',
+            },
+          },
+        },
+      },
+      length: 2,
+      name: 'root',
+      version: '1.0.0',
+    }
+
+    t.same(
+      await read({ path, workspaces: ['a'] }),
+      expected,
+      'should filter by workspace name'
+    )
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Adds support to a new `workspaces` option, that accepts an array of
strings, allowing users to filter the resulting fund info to a specific
set of workspaces and their dependencies.

## References
Relates to: https://github.com/npm/statusboard/issues/301
